### PR TITLE
Added MRPT_INCLUDE_DIRS and MRPT_LINK_DIRECTORIES for external usage.

### DIFF
--- a/parse-files/MRPTConfig.cmake.in
+++ b/parse-files/MRPTConfig.cmake.in
@@ -23,6 +23,8 @@
 #
 #   This file will define the following variables:
 #    - MRPT_LIBS: The list of libraries to links against.
+#    - MRPT_INCLUDE_DIRS: The list of include directories
+#    - MRTP_LINK_DIRECTORIES: The list of link directories
 #    - MRPT_VERSION: The MRPT version (e.g. "1.0.0"). 
 #    - MRPT_VERSION_{MAJOR,MINOR,PATCH}: 3 variables for the version parts
 #
@@ -55,12 +57,19 @@ SET(MRPT_CONFIG_DIR "@THE_MRPT_CONFIG_FILE_INCLUDE_DIR@")
 
 #MESSAGE(STATUS "MRPT_FIND_COMPONENTS: ${MRPT_FIND_COMPONENTS}")
 
+# MRPT include directories
+SET(MRPT_INCLUDE_DIRS "@THE_INCLUDE_DIRECTORIES@")
+
+# MRPT library directories
+SET(MRPT_LINK_DIRECTORIES "@THE_LINK_DIRECTORIES@")
+
 # ======================================================
 # Include directories where Eigen3 headers are... if 
 #  they are not embedded under mrpt-base headers:
 # ======================================================
 IF (NOT @MRPT_CONFIGFILE_IS_INSTALL@ OR NOT @EIGEN_USE_EMBEDDED_VERSION_BOOL@)
 	INCLUDE_DIRECTORIES("@MRPT_EIGEN_INCLUDE_DIR@")
+	LIST(APPEND MRPT_INCLUDE_DIRS "@MRPT_EIGEN_INCLUDE_DIR@")
 ENDIF (NOT @MRPT_CONFIGFILE_IS_INSTALL@ OR NOT @EIGEN_USE_EMBEDDED_VERSION_BOOL@)
 
 # If using GCC and -Wall, eigen3 headers raise some warnings: silent them:
@@ -73,6 +82,7 @@ ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 # Include directories to add to the user project:
 # ======================================================
 INCLUDE_DIRECTORIES(${MRPT_CONFIG_DIR})
+LIST(APPEND MRPT_INCLUDE_DIRS ${MRPT_CONFIG_DIR})
 
 # OpenCV library:
 IF(@CMAKE_MRPT_HAS_OPENCV_SYSTEM@)    # CMAKE_MRPT_HAS_OPENCV_SYSTEM
@@ -80,12 +90,14 @@ IF(@CMAKE_MRPT_HAS_OPENCV_SYSTEM@)    # CMAKE_MRPT_HAS_OPENCV_SYSTEM
 	# Users must link against OpenCV only if MRPT is not a dynamic library:
 	IF (NOT @CMAKE_MRPT_BUILD_SHARED_LIB_ONOFF@)  # CMAKE_MRPT_BUILD_SHARED_LIB
 		LINK_DIRECTORIES("@OPENCV_LIBDIR@")  # OPENCV_LIBDIR
+		LIST(APPEND MRPT_LINK_DIRECTORIES "@OPENCV_LIBDIR@")
 	ENDIF (NOT @CMAKE_MRPT_BUILD_SHARED_LIB_ONOFF@)
 ENDIF(@CMAKE_MRPT_HAS_OPENCV_SYSTEM@)
 
 # Suitesparse lib (only if present as a system lib)
 IF(@CMAKE_MRPT_HAS_SUITESPARSE_SYSTEM@)    # CMAKE_MRPT_HAS_SUITESPARSE_SYSTEM
 	INCLUDE_DIRECTORIES("@SuiteSparse_INCLUDE_DIRS@") # SuiteSparse_INCLUDE_DIRS
+	LIST(APPEND MRPT_INCLUDE_DIRS "@SuiteSparse_INCLUDE_DIRS@")
 ENDIF(@CMAKE_MRPT_HAS_SUITESPARSE_SYSTEM@)
 
 
@@ -161,6 +173,7 @@ FOREACH(MRPTLIB ${MRPT_FIND_COMPONENTS})
 
 	# The include dir:
 	INCLUDE_DIRECTORIES("${MRPT_LIBS_INCL_DIR}/${MRPTLIB}/include")
+	LIST(APPEND MRPT_INCLUDE_DIRS "${MRPT_LIBS_INCL_DIR}/${MRPTLIB}/include")
 
 	# List of link libs only needed in GCC. In MSVC we use pragma link libs.
 	IF(NOT MSVC AND NOT BORLAND)
@@ -209,6 +222,7 @@ IF(@CMAKE_MRPT_HAS_WXWIDGETS@ AND NOT @CMAKE_MRPT_BUILD_SHARED_LIB_ONOFF@)  # CM
 		INCLUDE(${wxWidgets_USE_FILE})
 		# ${wxWidgets_LIBRARIES}  will contain the libraries that should be added through TARGET_LINK_LIBRARIES(...)
 		LINK_DIRECTORIES(${wxWidgets_LIBRARY_DIRS})
+		LIST(APPEND MRPT_LINK_DIRECTORIES ${wxWidgets_LIBRARY_DIRS})
 
 		IF(MSVC)
 			ADD_DEFINITIONS(-DwxUSE_NO_MANIFEST=1)
@@ -230,6 +244,8 @@ IF(WIN32 AND NOT @CMAKE_MRPT_BUILD_SHARED_LIB_ONOFF@)
 	IF(@CMAKE_MRPT_HAS_BUMBLEBEE@)   # CMAKE_MRPT_HAS_BUMBLEBEE
 		LINK_DIRECTORIES("@BUMBLEBEE_PGR_FLYCAPTURE_ROOT_DIR@/lib")
 		LINK_DIRECTORIES("@BUMBLEBEE_TRICLOPS_ROOT_DIR@/lib")
+		LIST(APPEND MRPT_LINK_DIRECTORIES "@BUMBLEBEE_PGR_FLYCAPTURE_ROOT_DIR@/lib")
+		LIST(APPEND MRPT_LINK_DIRECTORIES "@BUMBLEBEE_TRICLOPS_ROOT_DIR@/lib")
 	ENDIF(@CMAKE_MRPT_HAS_BUMBLEBEE@)
 ENDIF(WIN32 AND NOT @CMAKE_MRPT_BUILD_SHARED_LIB_ONOFF@)
 
@@ -237,4 +253,4 @@ ENDIF(WIN32 AND NOT @CMAKE_MRPT_BUILD_SHARED_LIB_ONOFF@)
 # Link directories to add to the user project:
 # ======================================================
 LINK_DIRECTORIES(${MRPT_DIR}/lib)
-
+LIST(APPEND MRPT_LINK_DIRECTORIES ${MRPT_DIR}/lib)


### PR DESCRIPTION
Hi Luis,

I added the variable MRPT_INCLUDE_DIRS and MRPT_LINK_DIRECTORIES for useage in external CMakeLists (e.g. to get it into parent-scope, when having more complex projects).
It would be nice if you could consider that.

Thanks,
Andreas